### PR TITLE
awxkit: replace deprecated `locale.format()` with `locale.format_string()` to fix human output on Python 3.12

### DIFF
--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -185,7 +185,7 @@ def format_human(output, fmt):
 
     def format_num(v):
         try:
-            return locale.format("%.*f", (0, int(v)), True)
+            return locale.format_string("%.*f", (0, int(v)), True)
         except (ValueError, TypeError):
             if isinstance(v, (list, dict)):
                 return json.dumps(v)


### PR DESCRIPTION
This will be removed in Python 3.12 and will break human output unless fixed.

##### SUMMARY
In Python 3.12 the deprecated function `locale.formt` was removed as mentioned here: https://github.com/python/cpython/issues/94226
This leads to an error on Python 3.12

```
$ awx jobs list                                                                                     
module 'locale' has no attribute 'format
```
as can be tested on Fedora >=39 or any machine running Python 3.12.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI


##### AWX VERSION
awxcli:
```
$ awx --version
24.3.1
```

